### PR TITLE
fix: React and Next fixes for CVE-2025-55184 and CVE-2025-55183

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@happyrobotai/web-client": "^2.9.1",
         "@tailwindcss/vite": "^4.0.6",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.0.3",
+        "react-dom": "^19.0.3",
         "tailwindcss": "^4.0.6"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.6",
     "@happyrobotai/web-client": "^2.9.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.0.3",
+    "react-dom": "^19.0.3",
     "tailwindcss": "^4.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates react and next to address CVE-2025-55184 and CVE-2025-55183

**Changes:**
- react 19.0.0 → 19.0.3
- react-dom 19.0.0 → 19.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React and React-DOM dependencies to the latest patch versions for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->